### PR TITLE
Bugfix-pointer offset in readSingleBlock

### DIFF
--- a/PN5180ISO15693.cpp
+++ b/PN5180ISO15693.cpp
@@ -250,7 +250,7 @@ ISO15693ErrorCode PN5180ISO15693::readSingleBlock(uint8_t *uid, uint8_t blockNo,
   PN5180DEBUG("Value=");
   
   for (int i=0; i<blockSize; i++) {
-    blockData[i] = resultPtr[2+i];
+    blockData[i] = resultPtr[1+i];
 #ifdef DEBUG    
     PN5180DEBUG(formatHex(blockData[i]));
     PN5180DEBUG(" ");


### PR DESCRIPTION
This once already was fixed but sneaked somehow in again. (It is corrected at the ATrappmann-s fork).