### PR TITLE
improve debugging (should have NO functional changes)

### DIFF
--- a/Debug.cpp
+++ b/Debug.cpp
@@ -17,6 +17,7 @@
 // Lesser General Public License for more details.
 //
 #include <inttypes.h>
+#include <Arduino.h>
 #include "Debug.h"
 
 #ifdef DEBUG

--- a/Debug.h
+++ b/Debug.h
@@ -19,8 +19,6 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
-#define DEBUG
-
 #ifdef DEBUG
 #define PN5180DEBUG(msg) Serial.print(msg)
 #else

--- a/Debug.h
+++ b/Debug.h
@@ -19,6 +19,8 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
+#define DEBUG
+
 #ifdef DEBUG
 #define PN5180DEBUG(msg) Serial.print(msg)
 #else

--- a/PN5180ISO14443.cpp
+++ b/PN5180ISO14443.cpp
@@ -20,7 +20,7 @@
 
 #include <Arduino.h>
 #include "PN5180ISO14443.h"
-#include <PN5180.h>
+#include "PN5180.h"
 #include "Debug.h"
 
 PN5180ISO14443::PN5180ISO14443(uint8_t SSpin, uint8_t BUSYpin, uint8_t RSTpin, SPIClass& spi) 

--- a/PN5180ISO15693.h
+++ b/PN5180ISO15693.h
@@ -64,7 +64,7 @@ public:
    */
 public:   
   bool setupRF();
-  const __FlashStringHelper *strerror(ISO15693ErrorCode errno);
+  const __FlashStringHelper *strerror(ISO15693ErrorCode err);
     
 };
 


### PR DESCRIPTION
I was debugging some PN5180 things and ended up redoing the debugging prints in this library a bunch. None of this should have any effect whatsoever if DEBUG is off.

Specifically, this should make debugging output both much smaller and much more legible. Basically it has the basic protocol functions decode the SPI transactions (and ISO15693 messages, in PN5180ISO15693.cpp) including things like register values, that way no matter how any given register is accessed or how a command is sent it gets printed nicely. That lets me remove lots and lots of other debugging that was often redundant.

Here's what the output looks like for a simple inventory command:

```
SPI pinout: SS=10, MOSI=11, MISO=13, SCK=12
Resetting PN5180...
Sending SPI frame: [READ_REGISTER IRQ_STATUS]
Receive SPI frame: [04 00 00 00]
=> IRQ-Status=0x00000004: Idle
Sending SPI frame: [READ_EEPROM PRODUCT_VERSION 02]
Receive SPI frame: [00 04]
Sending SPI frame: [READ_EEPROM FIRMWARE_VERSION 02]
Receive SPI frame: [00 04]
Sending SPI frame: [READ_EEPROM EEPROM_VERSION 02]
Receive SPI frame: [00 99]
Sending SPI frame: [LOAD_RF_CONFIG 0D 8D]
Sending SPI frame: [RF_ON 00]
Sending SPI frame: [READ_REGISTER IRQ_STATUS]
Receive SPI frame: [04 02 00 00]
=> IRQ-Status=0x00000204: TxRFOn Idle
Sending SPI frame: [WRITE_REGISTER IRQ_CLEAR 00 02 00 00]
Sending SPI frame: [WRITE_REGISTER_AND_MASK SYSTEM_CONFIG F8 FF FF FF]
Sending SPI frame: [WRITE_REGISTER_OR_MASK SYSTEM_CONFIG 03 00 00 00]
Sending ISO15693 [(1Sub HiRate Inv 1Slot) INVENTORY 00]
Sending SPI frame: [WRITE_REGISTER_AND_MASK SYSTEM_CONFIG F8 FF FF FF]
Sending SPI frame: [WRITE_REGISTER_OR_MASK SYSTEM_CONFIG 03 00 00 00]
Sending SPI frame: [READ_REGISTER RF_STATUS]
Receive SPI frame: [55 01 62 01]
=> RF-Status=0x01620155: WaitTransmit DPC=0x06 TxRF AGC=0x341
Sending SPI frame: [SEND_DATA 00 26 01 00]
Sending SPI frame: [READ_REGISTER IRQ_STATUS]
Receive SPI frame: [07 40 00 00]
=> IRQ-Status=0x00004007: RxSOFDet Idle TxDone RxDone
Sending SPI frame: [READ_REGISTER RX_STATUS]
Receive SPI frame: [0A 00 00 00]
=> RX-Status=0x0000000A: bytes=10
Sending SPI frame: [READ_DATA 00]
Receive SPI frame: [00 00 D3 CC 59 09 53 01 04 E0]
Sending SPI frame: [READ_REGISTER IRQ_STATUS]
Receive SPI frame: [07 40 00 00]
=> IRQ-Status=0x00004007: RxSOFDet Idle TxDone RxDone
Sending SPI frame: [WRITE_REGISTER IRQ_CLEAR 07 40 00 00]
Response flags: 00, Data Storage Format ID: 00, UID: 00:00:00000959CCD3
```